### PR TITLE
Reduce the number of fields in the Subscriber class.

### DIFF
--- a/src/main/java/kiss/Disposable.java
+++ b/src/main/java/kiss/Disposable.java
@@ -9,6 +9,7 @@
  */
 package kiss;
 
+import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Future;
 
@@ -31,15 +32,15 @@ public interface Disposable {
      */
     default void dispose() {
         // dispose children
-        Subscriber<Disposable> subscriber = Subscriber.of(this);
+        Subscriber<List<Disposable>> subscriber = Subscriber.of(this);
 
         if (subscriber.index == 0) {
             // mark as disposed
             subscriber.index++;
 
-            if (subscriber.list != null) {
-                subscriber.list.forEach(Disposable::dispose);
-                subscriber.list = null;
+            if (subscriber.o != null) {
+                subscriber.o.forEach(Disposable::dispose);
+                subscriber.o = null;
             }
 
             // dispose self
@@ -64,12 +65,12 @@ public interface Disposable {
      */
     default Disposable add(Disposable next) {
         if (next != null && next != this) {
-            Subscriber subscriber = Subscriber.of(this);
+            Subscriber<List> subscriber = Subscriber.of(this);
 
-            if (subscriber.list == null) {
-                subscriber.list = new CopyOnWriteArrayList();
+            if (subscriber.o == null) {
+                subscriber.o = new CopyOnWriteArrayList();
             }
-            subscriber.list.add(next);
+            subscriber.o.add(next);
         }
         return this;
     }
@@ -94,7 +95,7 @@ public interface Disposable {
     default Disposable sub() {
         Disposable sub = empty();
         add(sub);
-        sub.add(() -> Subscriber.of(this).list.remove(sub));
+        sub.add(() -> ((List) Subscriber.of(this).o).remove(sub));
         return sub;
     }
 

--- a/src/main/java/kiss/I.java
+++ b/src/main/java/kiss/I.java
@@ -1027,8 +1027,8 @@ public class I implements ParameterizedType {
             Subscriber sub = new Subscriber();
             sub.observer = observer;
             sub.disposer = disposer;
-            sub.text = new StringBuilder();
             sub.next = open;
+            sub.o = new StringBuilder();
 
             return disposer.add(I.signal(client)
                     .to()

--- a/src/main/java/kiss/Signal.java
+++ b/src/main/java/kiss/Signal.java
@@ -2420,12 +2420,12 @@ public class Signal<V> {
             Subscriber<E> sub = new Subscriber();
             sub.next = e -> {
                 // recorde the processing error
-                sub.observer.accept(sub.obj = e);
+                sub.observer.accept(sub.o = e);
             };
 
             // define error recovering flow
             flow.apply(sub.signal()).to(v -> {
-                sub.obj = null; // processing error will be handled, so clear it
+                sub.o = null; // processing error will be handled, so clear it
                 if (v == UNDEF) {
                     observer.complete();
                 } else {
@@ -2441,7 +2441,7 @@ public class Signal<V> {
 
                 // The following code is not used as it may send null.
                 // if (sub.obj != null) observer.error(sub.obj);
-                Throwable t = sub.obj;
+                Throwable t = sub.o;
                 if (t != null) observer.error(t);
             });
 
@@ -2483,7 +2483,7 @@ public class Signal<V> {
             Subscriber<Object> sub = new Subscriber();
             WiseRunnable complete = () -> {
                 // recorde the processing completion
-                sub.accept(sub.obj = UNDEF);
+                sub.accept(sub.o = UNDEF);
             };
 
             // number of remaining repeats
@@ -2493,7 +2493,7 @@ public class Signal<V> {
 
             // define complete repeating flow
             flow.apply(sub.signal()).to(v -> {
-                sub.obj = null; // processing complete will be handled, so clear it
+                sub.o = null; // processing complete will be handled, so clear it
 
                 // If you are not repeating, repeat it immediately, otherwise you can do it later
                 if (remaining.getAndIncrement() == 0) {
@@ -2510,7 +2510,7 @@ public class Signal<V> {
 
                 // Since there is a complete in processing, but this complete flow has ended,
                 // the processing complete is passed to the source signal.
-                if (sub.obj != null) observer.complete();
+                if (sub.o != null) observer.complete();
             });
 
             // connect preassign complete handling flow
@@ -2561,7 +2561,7 @@ public class Signal<V> {
                 // recorde the processing error
                 //
                 // to user defined error flow
-                sub.observer.accept(sub.obj = e);
+                sub.observer.accept(sub.o = e);
             };
 
             // number of remaining retry
@@ -2571,7 +2571,7 @@ public class Signal<V> {
 
             // define error retrying flow
             flow.apply(sub.signal()).to(v -> {
-                sub.obj = null; // processing error will be handled, so clear it
+                sub.o = null; // processing error will be handled, so clear it
 
                 // If you are not retrying, retry it immediately, otherwise you can do it later
                 if (remaining.getAndIncrement() == 0) {
@@ -2591,7 +2591,7 @@ public class Signal<V> {
                 //
                 // The following code is not used as it may send null.
                 // if (sub.obj != null) observer.error(sub.obj);
-                Throwable t = sub.obj;
+                Throwable t = sub.o;
                 if (t != null) observer.error(t);
             });
 

--- a/src/main/java/kiss/Subscriber.java
+++ b/src/main/java/kiss/Subscriber.java
@@ -157,8 +157,6 @@ class Subscriber<T> implements Observer<T>, Disposable, WebSocket.Listener, Stor
     // ======================================================================
     // Websocket Listener
     // ======================================================================
-    StringBuilder text;
-
     byte[] a;
 
     /**
@@ -175,17 +173,19 @@ class Subscriber<T> implements Observer<T>, Disposable, WebSocket.Listener, Stor
      */
     @Override
     public CompletionStage<?> onText(WebSocket web, CharSequence data, boolean last) {
+        StringBuilder b = (StringBuilder) o;
+
         if (last) {
             // If there is a pre-buffered string, it must be concatenated.
             // If not, we can stringify directly to avoid unnecessary bytes copying.
-            if (text.length() == 0) {
+            if (b.length() == 0) {
                 observer.accept(data.toString());
             } else {
-                observer.accept(text.append(data).toString());
-                text.setLength(0);
+                observer.accept(b.append(data).toString());
+                b.setLength(0);
             }
         } else {
-            text.append(data);
+            b.append(data);
         }
         return null;
     }
@@ -249,7 +249,7 @@ class Subscriber<T> implements Observer<T>, Disposable, WebSocket.Listener, Stor
      * @param lang An associated language.
      */
     Subscriber(String lang) {
-        text = new StringBuilder(lang);
+        o = (T) lang;
         messages = new ConcurrentSkipListMap();
 
         restore();
@@ -260,6 +260,6 @@ class Subscriber<T> implements Observer<T>, Disposable, WebSocket.Listener, Stor
      */
     @Override
     public Path locate() {
-        return Path.of(I.env("LangDirectory", "lang") + "/" + text + ".json");
+        return Path.of(I.env("LangDirectory", "lang") + "/" + o + ".json");
     }
 }

--- a/src/main/java/kiss/Subscriber.java
+++ b/src/main/java/kiss/Subscriber.java
@@ -16,7 +16,6 @@ import java.net.http.WebSocket;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.util.List;
 import java.util.Map;
 import java.util.WeakHashMap;
 import java.util.concurrent.CompletionStage;
@@ -41,9 +40,6 @@ class Subscriber<T> implements Observer<T>, Disposable, WebSocket.Listener, Stor
 
     /** Generic object. */
     T o;
-
-    /** Generic list. */
-    List<T> list;
 
     OutputStream out;
 

--- a/src/main/java/kiss/Subscriber.java
+++ b/src/main/java/kiss/Subscriber.java
@@ -11,10 +11,9 @@ package kiss;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.net.http.WebSocket;
 import java.nio.ByteBuffer;
-import java.nio.CharBuffer;
-import java.nio.charset.CharsetEncoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.List;
@@ -41,10 +40,12 @@ class Subscriber<T> implements Observer<T>, Disposable, WebSocket.Listener, Stor
     volatile long time;
 
     /** Generic object. */
-    T obj;
+    T o;
 
     /** Generic list. */
     List<T> list;
+
+    OutputStream out;
 
     /**
      * {@link Subscriber} must have this constructor only. Don't use instance field initialization
@@ -265,13 +266,4 @@ class Subscriber<T> implements Observer<T>, Disposable, WebSocket.Listener, Stor
     public Path locate() {
         return Path.of(I.env("LangDirectory", "lang") + "/" + text + ".json");
     }
-
-    // ======================================================================
-    // Logging
-    // ======================================================================
-    CharBuffer chars;
-
-    ByteBuffer bytes;
-
-    CharsetEncoder encoder;
 }

--- a/src/test/java/kiss/LogBenchmark.java
+++ b/src/test/java/kiss/LogBenchmark.java
@@ -74,9 +74,9 @@ public class LogBenchmark {
 
         // performJUL(benchmark);
         performSinobu(benchmark);
-        performLog4j(benchmark);
-        performTinyLog(benchmark);
-        performLogback(benchmark);
+        // performLog4j(benchmark);
+        // performTinyLog(benchmark);
+        // performLogback(benchmark);
 
         benchmark.perform();
     }


### PR DESCRIPTION
Attempted to reduce the number of fields in the Subscriber class because there are too many. Since memory usage increases linearly with the increase in instances even for unused fields, it makes sense to reduce the fields themselves.